### PR TITLE
Do not use document.write

### DIFF
--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -31,9 +31,7 @@
 
 
     </div>
-    <script>
-      window.jQuery || document.write('<script src="{{post.path}}/scripts/vendor/jquery.min.js"><\/script>');
-    </script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
     <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js"></script>
     <script src="{{post.path}}/scripts/main.min.js"></script>
   </body>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -31,8 +31,8 @@
 
 
     </div>
-    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
-    <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js"></script>
-    <script src="{{post.path}}/scripts/main.min.js"></script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js" defer></script>
+    <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js" defer></script>
+    <script src="{{post.path}}/scripts/main.min.js" defer></script>
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,9 +26,7 @@
     <div id="page">
     {{content}}
     </div>
-    <script>
-      window.jQuery || document.write('<script src="{{page.path}}/scripts/vendor/jquery.min.js"><\/script>');
-    </script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
     <script src="{{page.path}}/scripts/vendor/responsiveslides.min.js"></script>
     <script src="{{page.path}}/scripts/main.min.js"></script>
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,8 +26,8 @@
     <div id="page">
     {{content}}
     </div>
-    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
-    <script src="{{page.path}}/scripts/vendor/responsiveslides.min.js"></script>
-    <script src="{{page.path}}/scripts/main.min.js"></script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js" defer></script>
+    <script src="{{page.path}}/scripts/vendor/responsiveslides.min.js" defer></script>
+    <script src="{{page.path}}/scripts/main.min.js" defer></script>
   </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,9 +39,7 @@
 
 
     </div>
-    <script>
-      window.jQuery || document.write('<script src="{{post.path}}/scripts/vendor/jquery.min.js"><\/script>');
-    </script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
     <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js"></script>
     <script src="{{post.path}}/scripts/main.min.js"></script>
   </body>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,8 +39,8 @@
 
 
     </div>
-    <script src="{{post.path}}/scripts/vendor/jquery.min.js"></script>
-    <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js"></script>
-    <script src="{{post.path}}/scripts/main.min.js"></script>
+    <script src="{{post.path}}/scripts/vendor/jquery.min.js" defer></script>
+    <script src="{{post.path}}/scripts/vendor/responsiveslides.min.js" defer></script>
+    <script src="{{post.path}}/scripts/main.min.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
After removing the CDN jQuery, we no longer have to conditionally load
our own version.

On chrome, scripts added with `document.write` won't load on 2G connections, which would break the followed scripts.